### PR TITLE
Create new HTTP connection per request.

### DIFF
--- a/lib/recharge/http_request.rb
+++ b/lib/recharge/http_request.rb
@@ -80,6 +80,7 @@ module Recharge
         request.set_debug_output(
           Recharge.debug.is_a?(IO) ? Recharge.debug : $stderr
         )
+      end
 
       request.start do |http|
         res = http.request(req)


### PR DESCRIPTION
Rather than re-using the connection on the class instance.

`bundle exec rake` passes on mudwtr_recharge with this branch set in the Gemfile.

```
Finished in 1.12 seconds (files took 5.3 seconds to load)
45 examples, 0 failures
```

Do you think this could address the issue? Or should we replace the `Net::HTTP.start` syntax with one-off post, get, delete, etc. calls?
